### PR TITLE
fix first-time installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information on the protocol you can read the [documentation](https://gi
 Make sure you have the ```go``` package installed.
 *Note: package name may vary based on distribution*
 
-You can then run ```go get github.com/VictorNine/bitwarden-go``` to fetch the latest code.
+You can then run ```go get github.com/VictorNine/bitwarden-go/cmd/bitwarden-go``` to fetch the latest code.
 
 #### Build/Install
 Run in your favorite terminal:


### PR DESCRIPTION
previous implementation doesn't actually fetch any dependencies:

```
go get -v github.com/VictorNine/bitwarden-go
can't load package: package github.com/VictorNine/bitwarden-go:
  no Go files in /repos/go/src/github.com/VictorNine/bitwarden-go
```